### PR TITLE
🐞 |tv|fix arrayIndexOutoufBounds for weird string by removing duplica…

### DIFF
--- a/src/main/java/de/otto/sluggify/Sluggify.java
+++ b/src/main/java/de/otto/sluggify/Sluggify.java
@@ -306,43 +306,11 @@ public class Sluggify {
     }
 
     private static String doSlugify(String string) {
-        if (string == null) return null;
-
         string = string.replaceAll("([a-z])'s([^a-z])", "$1s$2"); // WTF ?
         string = removeSpecialCharactersAndConvertToLowercase(string);
 
         string = string.replaceAll("-+$", "").replaceAll("^-+", "");
-        string = removeLeadingAndTrailingHyphens(string);
 
         return string;
-    }
-
-    private static String removeLeadingAndTrailingHyphens(String string) {
-        int leadingHyphens = numberOfLeadingHyphens(string);
-        if (leadingHyphens > 0) {
-            string = string.substring(leadingHyphens);
-        }
-        int trailingHyphens = numberOfTrailingHyphens(string);
-        if (trailingHyphens > 0) {
-            string = string.substring(0, string.length() - trailingHyphens);
-        }
-        return string;
-    }
-
-    private static int numberOfTrailingHyphens(String input) {
-        int len = input.length();
-        int idx = 0;
-        while (input.charAt(len - idx - 1) == '-') {
-            ++idx;
-        }
-        return idx;
-    }
-
-    private static int numberOfLeadingHyphens(String input) {
-        int idx = 0;
-        while (input.charAt(idx) == '-') {
-            ++idx;
-        }
-        return idx;
     }
 }

--- a/src/test/java/de/otto/sluggify/SluggifyTest.java
+++ b/src/test/java/de/otto/sluggify/SluggifyTest.java
@@ -54,6 +54,11 @@ public class SluggifyTest {
     }
 
     @Test
+    public void shouldSluggifySingleWeirdCharacter() {
+        assertThat(Sluggify.sluggify("®"), is(""));
+    }
+
+    @Test
     public void shouldSlugifyNullsAndEmptyStrings() {
         assertThat(Sluggify.sluggify(null), is(nullValue()));
         assertThat(Sluggify.sluggify(""), is(""));


### PR DESCRIPTION
…te logic.

Removing leading and trailing hyphens is already done in line 312 (previously 314), so the code is not necessary. Plus it resulted in exceptions for weird edge cases (see test case).

The null-check in line 309 is unnecessary because line 280 checks for isEmpty.

